### PR TITLE
Fix typing to match with the current type definition of formik validation function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "formik-validator-zod",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "formik-validator-zod",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "devDependencies": {
         "formik": "^2.2.9",


### PR DESCRIPTION
When using this library I noticed that the schema was not valid anymore as shown in the example.

I tried to reformulate the type matching of the two libraries, Zod and Formik, so that Typescript stopped complaining about the type matching originally implemented.